### PR TITLE
list images in order on index

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,3 +13,7 @@
  *= require_tree .
  *= require_self
  */
+
+.img {
+  max-width: 400px;
+}

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -1,4 +1,8 @@
 class ImagesController < ApplicationController
+  def index
+    @images = Image.all.recent
+  end
+
   def new
     @image = Image.new
   end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,3 +1,5 @@
 class Image < ApplicationRecord
   validates :url, presence: true, null: false, format: { with: URI.regexp(%w[http https]) }
+
+  scope :recent, -> { order(created_at: :desc) }
 end

--- a/app/views/images/index.html.erb
+++ b/app/views/images/index.html.erb
@@ -1,0 +1,3 @@
+<% @images.each do |image| %>
+  <%= image_tag(image.url, :class => "img") %>
+<% end %>

--- a/app/views/images/show.html.erb
+++ b/app/views/images/show.html.erb
@@ -1,1 +1,1 @@
-<img src=<%= @image.url %>>
+<%= image_tag(@image.url, :class => "img") %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root 'application#home'
 
-  resources :images, only: %i[new create show]
+  resources :images, only: %i[index new create show]
 end

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -17,9 +17,14 @@ class ImagesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  def test_index
+  def test_show
     image = images(:one)
     get image_url(image)
+    assert_response :success
+  end
+
+  def test_index
+    get images_url
     assert_response :success
   end
 end

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -22,4 +22,11 @@ class ImageTest < ActiveSupport::TestCase
     image = Image.new(url: 'test')
     assert_not image.valid?
   end
+
+  def test_image__recent_in_order
+    older_image = Image.create(url: 'https://www.w3schools.com/w3css/img_lights.jpg')
+    newer_image = Image.create(url: 'https://www.w3schools.com/w3css/img_lights.jpg')
+
+    assert_equal [newer_image, older_image], Image.recent.to_a.first(2)
+  end
 end

--- a/test/routes/image_routes_test.rb
+++ b/test/routes/image_routes_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class SaveImageLinkTest < ActionDispatch::IntegrationTest
+class ImageRoutesTest < ActionDispatch::IntegrationTest
   def test_link__visible
     get '/'
     assert_select "a:match('href', ?)", %r{images/new}
@@ -9,5 +9,10 @@ class SaveImageLinkTest < ActionDispatch::IntegrationTest
   def test_form__visible
     get '/images/new'
     assert_select 'form', 1
+  end
+
+  def test_index
+    get '/images'
+    assert_select 'img', Image.all.count
   end
 end


### PR DESCRIPTION
- Added method on model to sort images in ascending order by created date
- Display all images on index with 400px max-width
- Tests for route, controller, and model

closes #3 

![img](https://images.pexels.com/photos/1485548/pexels-photo-1485548.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940)